### PR TITLE
Add F4 matrix archiving option

### DIFF
--- a/src/neogb/la_ff_32.c
+++ b/src/neogb/la_ff_32.c
@@ -19,6 +19,7 @@
  * Mohab Safey El Din */
 
 #include "data.h"
+#include "tools.h"
 
 /* That's also enough if AVX512 is avaialable on the system */
 #if defined HAVE_AVX2
@@ -4121,9 +4122,11 @@ static void exact_sparse_dense_linear_algebra_ff_32(
     /* generate updated dense D part via reduction of CD with AB */
     cf32_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_32(mat, bs, st);
+    dump_dense_matrix_cf32(dm, mat->np, ncr);
     if (mat->np > 0) {
         dm  = exact_dense_linear_algebra_ff_32(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_32(dm, ncr, st->fc);
+        dump_dense_matrix_cf32(dm, mat->np, ncr);
     }
 
     /* convert dense matrix back to sparse matrix representation,
@@ -4171,9 +4174,11 @@ static void probabilistic_sparse_dense_linear_algebra_ff_32_2(
     /* generate updated dense D part via reduction of CD with AB */
     cf32_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_32(mat, bs, st);
+    dump_dense_matrix_cf32(dm, mat->np, ncr);
     if (mat->np > 0) {
         dm  = probabilistic_dense_linear_algebra_ff_32(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_32(dm, mat->ncr, st->fc);
+        dump_dense_matrix_cf32(dm, mat->np, ncr);
     }
 
     /* convert dense matrix back to sparse matrix representation,
@@ -4222,7 +4227,9 @@ static void probabilistic_sparse_dense_linear_algebra_ff_32(
     cf32_t **dm = NULL;
     mat->np = 0;
     dm      = probabilistic_sparse_dense_echelon_form_ff_32(mat, bs, st);
+    dump_dense_matrix_cf32(dm, mat->np, ncr);
     dm      = interreduce_dense_matrix_ff_32(dm, mat->ncr, st->fc);
+    dump_dense_matrix_cf32(dm, mat->np, ncr);
 
     /* convert dense matrix back to sparse matrix representation,
      * use tmpcf for storing the coefficient arrays */

--- a/src/neogb/tools.h
+++ b/src/neogb/tools.h
@@ -35,6 +35,13 @@ double realtime(
     void
     );
 
+extern int save_matrices;
+void dump_dense_matrix_cf32(
+    cf32_t **mat,
+    len_t nrows,
+    len_t ncols
+    );
+
 static inline uint8_t mod_p_inverse_8(
         const int16_t val,
         const int16_t p


### PR DESCRIPTION
## Summary
- add -x flag to archive F4 matrices before and after row reduction
- implement dumping of dense matrices in `tools.c`
- enable matrix archiving when using dense linear algebra and warn if forced

## Testing
- `make -j4`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6840459685dc832ab262274584407a8d