### PR TITLE
Add F4 matrix archiving option

### DIFF
--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -19,10 +19,22 @@
  * Mohab Safey El Din */
 
 #include "libmsolve.c"
+#include "../neogb/tools.h"
+#include <time.h>
+#include <stdint.h>
 
 #define DEBUGGB 0
 #define DEBUGBUILDMATRIX 0
 #define IO_DEBUG 0
+
+static int is_prime32(uint32_t p) {
+    if (p < 2) return 0;
+    if (p % 2 == 0) return p == 2;
+    for (uint32_t i = 3; i * (uint64_t)i <= p; i += 2) {
+        if (p % i == 0) return 0;
+    }
+    return 1;
+}
 
 static inline void display_help(char *str){
   fprintf(stdout, "\nmsolve library for polynomial system solving, version %s\n", VERSION);
@@ -145,6 +157,7 @@ static inline void display_help(char *str){
   fprintf(stdout, "         hash table is newly generated.\n");
   fprintf(stdout, "         Default: 0, i.e. no update.\n");
   fprintf(stdout, "-V       Prints msolve's version\n");
+  fprintf(stdout, "-x       Archive F4 matrices before and after row reduction\n");
 }
 
 static void getoptions(
@@ -181,7 +194,7 @@ static void getoptions(
   char *out_fname = NULL;
   char *bin_out_fname = NULL;
   opterr = 1;
-  char options[] = "hf:N:F:v:l:t:e:o:O:u:iI:p:P:L:q:g:c:s:SCr:R:m:M:n:d:Vf:";
+  char options[] = "hf:N:F:v:l:t:e:o:O:u:iI:p:P:L:q:g:c:s:SCr:R:m:M:n:d:Vf:x";
   while((opt = getopt(argc, argv, options)) != -1) {
     switch(opt) {
     case 'N':
@@ -318,6 +331,9 @@ static void getoptions(
           *normal_form_matrix  = 0;
       }
       break;
+    case 'x':
+      save_matrices = 1;
+      break;
     default:
       errflag++;
       break;
@@ -386,6 +402,11 @@ int main(int argc, char **argv){
                &normal_form, &normal_form_matrix, &is_gb, &lift_matrix, &get_param,
                &precision, &refine, &isolate, &generate_pbm, &info_level, files);
 
+    srand(time(0));
+    if (save_matrices && info_level > 1) {
+        fprintf(stderr, "Matrix archiving enabled.\n");
+    }
+
     FILE *fh  = fopen(files->in_file, "r");
     FILE *bfh  = fopen(files->bin_file, "r");
 
@@ -428,6 +449,19 @@ int main(int argc, char **argv){
     gens->rand_linear           = 0;
     gens->random_linear_form = malloc(sizeof(int32_t)*(nr_vars));
     gens->elim = elim_block_len;
+
+    if (save_matrices) {
+        if (!is_prime32(field_char) || field_char > 0x7fffffff) {
+            save_matrices = 0;
+        } else {
+            if (la_option != 1) {
+                if (info_level > 0) {
+                    fprintf(stderr, "-x forces linear algebra option 1 for matrix archiving\n");
+                }
+                la_option = 1;
+            }
+        }
+    }
 
     if(0 < field_char && field_char < pow(2, 15) && la_option > 2){
         if(info_level){

--- a/src/neogb/la_ff_32.c
+++ b/src/neogb/la_ff_32.c
@@ -19,6 +19,7 @@
  * Mohab Safey El Din */
 
 #include "data.h"
+#include "tools.h"
 
 /* That's also enough if AVX512 is avaialable on the system */
 #if defined HAVE_AVX2
@@ -4121,9 +4122,11 @@ static void exact_sparse_dense_linear_algebra_ff_32(
     /* generate updated dense D part via reduction of CD with AB */
     cf32_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_32(mat, bs, st);
+    dump_dense_matrix_cf32(dm, mat->np, ncr, 0);
     if (mat->np > 0) {
         dm  = exact_dense_linear_algebra_ff_32(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_32(dm, ncr, st->fc);
+        dump_dense_matrix_cf32(dm, mat->np, ncr, 1);
     }
 
     /* convert dense matrix back to sparse matrix representation,
@@ -4171,9 +4174,11 @@ static void probabilistic_sparse_dense_linear_algebra_ff_32_2(
     /* generate updated dense D part via reduction of CD with AB */
     cf32_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_32(mat, bs, st);
+    dump_dense_matrix_cf32(dm, mat->np, ncr, 0);
     if (mat->np > 0) {
         dm  = probabilistic_dense_linear_algebra_ff_32(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_32(dm, mat->ncr, st->fc);
+        dump_dense_matrix_cf32(dm, mat->np, ncr, 1);
     }
 
     /* convert dense matrix back to sparse matrix representation,
@@ -4222,7 +4227,9 @@ static void probabilistic_sparse_dense_linear_algebra_ff_32(
     cf32_t **dm = NULL;
     mat->np = 0;
     dm      = probabilistic_sparse_dense_echelon_form_ff_32(mat, bs, st);
+    dump_dense_matrix_cf32(dm, mat->np, ncr, 0);
     dm      = interreduce_dense_matrix_ff_32(dm, mat->ncr, st->fc);
+    dump_dense_matrix_cf32(dm, mat->np, ncr, 1);
 
     /* convert dense matrix back to sparse matrix representation,
      * use tmpcf for storing the coefficient arrays */

--- a/src/neogb/tools.c
+++ b/src/neogb/tools.c
@@ -19,6 +19,7 @@
 
 
 #include "tools.h"
+#include <sys/stat.h>
 
 /* cpu time */
 double cputime(void)
@@ -32,10 +33,54 @@ double cputime(void)
 /* wall time */
 double realtime(void)
 {
-	struct timeval t;
-	gettimeofday(&t, NULL);
-	t.tv_sec -= (2017 - 1970)*3600*24*365;
-	return (1. + (double)t.tv_usec + ((double)t.tv_sec*1000000.)) / 1000000.;
+        struct timeval t;
+        gettimeofday(&t, NULL);
+        t.tv_sec -= (2017 - 1970)*3600*24*365;
+        return (1. + (double)t.tv_usec + ((double)t.tv_sec*1000000.)) / 1000000.;
+}
+
+int save_matrices = 0;
+
+void dump_dense_matrix_cf32(cf32_t **mat, len_t nrows, len_t ncols, int reduced)
+{
+    if (!save_matrices || !mat)
+        return;
+
+    mkdir("matrix_archive", 0755);
+
+    unsigned int id = (unsigned int)(rand() & 0xFFFFFF);
+    char fname[256];
+    snprintf(fname, sizeof(fname), "matrix_archive/%s%lu_%lu_%06x.smat",
+             reduced ? "rref_" : "unrref_",
+             (unsigned long)nrows, (unsigned long)ncols, id);
+
+    FILE *f = fopen(fname, "w");
+    if (!f)
+        return;
+
+    size_t nnz = 0;
+    for (len_t i = 0; i < nrows; ++i) {
+        if (!mat[i])
+            continue;
+        for (len_t j = 0; j < ncols; ++j) {
+            if (mat[i][j] != 0)
+                nnz++;
+        }
+    }
+
+    fprintf(f, "%lu %lu %lu\n", (unsigned long)nrows, (unsigned long)ncols,
+            (unsigned long)nnz);
+    for (len_t i = 0; i < nrows; ++i) {
+        if (!mat[i])
+            continue;
+        for (len_t j = 0; j < ncols; ++j) {
+            if (mat[i][j] != 0) {
+                fprintf(f, "%lu %lu %u\n", (unsigned long)i, (unsigned long)j,
+                        (unsigned)mat[i][j]);
+            }
+        }
+    }
+    fclose(f);
 }
 
 static void construct_trace(

--- a/src/neogb/tools.h
+++ b/src/neogb/tools.h
@@ -35,6 +35,14 @@ double realtime(
     void
     );
 
+extern int save_matrices;
+void dump_dense_matrix_cf32(
+    cf32_t **mat,
+    len_t nrows,
+    len_t ncols,
+    int reduced
+    );
+
 static inline uint8_t mod_p_inverse_8(
         const int16_t val,
         const int16_t p


### PR DESCRIPTION
## Summary
- add option to archive F4 matrices before and after row reduction
- dump matrices with `rref_` or `unrref_` prefix depending on reduction state
- only enable archiving for prime characteristics and force LA option 1

## Testing
- `make -j4`
- `make check`

------
https://chatgpt.com/codex/tasks/task_e_6840459685dc832ab262274584407a8d