### PR TITLE
Add F4 matrix archiving option

### DIFF
--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -19,10 +19,22 @@
  * Mohab Safey El Din */
 
 #include "libmsolve.c"
+#include "../neogb/tools.h"
+#include <time.h>
+#include <stdint.h>
 
 #define DEBUGGB 0
 #define DEBUGBUILDMATRIX 0
 #define IO_DEBUG 0
+
+static int is_prime32(uint32_t p) {
+    if (p < 2) return 0;
+    if (p % 2 == 0) return p == 2;
+    for (uint32_t i = 3; i * (uint64_t)i <= p; i += 2) {
+        if (p % i == 0) return 0;
+    }
+    return 1;
+}
 
 static inline void display_help(char *str){
   fprintf(stdout, "\nmsolve library for polynomial system solving, version %s\n", VERSION);
@@ -145,6 +157,7 @@ static inline void display_help(char *str){
   fprintf(stdout, "         hash table is newly generated.\n");
   fprintf(stdout, "         Default: 0, i.e. no update.\n");
   fprintf(stdout, "-V       Prints msolve's version\n");
+  fprintf(stdout, "-x       Archive F4 matrices before and after row reduction\n");
 }
 
 static void getoptions(
@@ -181,7 +194,7 @@ static void getoptions(
   char *out_fname = NULL;
   char *bin_out_fname = NULL;
   opterr = 1;
-  char options[] = "hf:N:F:v:l:t:e:o:O:u:iI:p:P:L:q:g:c:s:SCr:R:m:M:n:d:Vf:";
+  char options[] = "hf:N:F:v:l:t:e:o:O:u:iI:p:P:L:q:g:c:s:SCr:R:m:M:n:d:Vf:x";
   while((opt = getopt(argc, argv, options)) != -1) {
     switch(opt) {
     case 'N':
@@ -318,6 +331,9 @@ static void getoptions(
           *normal_form_matrix  = 0;
       }
       break;
+    case 'x':
+      save_matrices = 1;
+      break;
     default:
       errflag++;
       break;
@@ -386,6 +402,11 @@ int main(int argc, char **argv){
                &normal_form, &normal_form_matrix, &is_gb, &lift_matrix, &get_param,
                &precision, &refine, &isolate, &generate_pbm, &info_level, files);
 
+    srand(time(0));
+    if (save_matrices && info_level > 1) {
+        fprintf(stderr, "Matrix archiving enabled.\n");
+    }
+
     FILE *fh  = fopen(files->in_file, "r");
     FILE *bfh  = fopen(files->bin_file, "r");
 
@@ -428,6 +449,19 @@ int main(int argc, char **argv){
     gens->rand_linear           = 0;
     gens->random_linear_form = malloc(sizeof(int32_t)*(nr_vars));
     gens->elim = elim_block_len;
+
+    if (save_matrices) {
+        if (!is_prime32(field_char) || field_char > 0x7fffffff) {
+            save_matrices = 0;
+        } else {
+            if (la_option != 1) {
+                if (info_level > 0) {
+                    fprintf(stderr, "-x forces linear algebra option 1 for matrix archiving\n");
+                }
+                la_option = 1;
+            }
+        }
+    }
 
     if(0 < field_char && field_char < pow(2, 15) && la_option > 2){
         if(info_level){

--- a/src/neogb/la_ff_32.c
+++ b/src/neogb/la_ff_32.c
@@ -19,6 +19,7 @@
  * Mohab Safey El Din */
 
 #include "data.h"
+#include "tools.h"
 
 /* That's also enough if AVX512 is avaialable on the system */
 #if defined HAVE_AVX2
@@ -3914,7 +3915,11 @@ static void probabilistic_sparse_linear_algebra_ff_32(
      * coefficients of all pivot rows */
     mat->cf_32 = realloc(mat->cf_32,
             (unsigned long)mat->nr * sizeof(cf32_t *));
+    dump_sparse_matrix_cf32(mat, tbr, bs, 0, 0.0);
+    double r0 = realtime();
     probabilistic_sparse_reduced_echelon_form_ff_32(mat, bs, st);
+    double r1 = realtime();
+    dump_sparse_matrix_cf32(mat, NULL, NULL, 1, r1 - r0);
 
     /* timings */
     ct1 = cputime();
@@ -3973,7 +3978,11 @@ static void exact_sparse_linear_algebra_ff_32(
      * coefficients of all pivot rows */
     mat->cf_32  = realloc(mat->cf_32,
             (unsigned long)mat->nr * sizeof(cf32_t *));
+    dump_sparse_matrix_cf32(mat, tbr, bs, 0, 0.0);
+    double r0 = realtime();
     exact_sparse_reduced_echelon_form_ff_32(mat, tbr, bs, st);
+    double r1 = realtime();
+    dump_sparse_matrix_cf32(mat, NULL, NULL, 1, r1 - r0);
 
     /* timings */
     ct1 = cputime();
@@ -4054,7 +4063,11 @@ static int exact_application_sparse_linear_algebra_ff_32(
      * coefficients of all pivot rows */
     mat->cf_32 = realloc(mat->cf_32,
             (unsigned long)mat->nr * sizeof(cf32_t *));
+    dump_sparse_matrix_cf32(mat, NULL, bs, 0, 0.0);
+    double r0 = realtime();
     ret = exact_application_sparse_reduced_echelon_form_ff_32(mat, bs, st);
+    double r1 = realtime();
+    dump_sparse_matrix_cf32(mat, NULL, NULL, 1, r1 - r0);
 
     /* timings */
     ct1 = cputime();
@@ -4087,7 +4100,11 @@ static void exact_trace_sparse_linear_algebra_ff_32(
      * coefficients of all pivot rows */
     mat->cf_32  = realloc(mat->cf_32,
             (unsigned long)mat->nr * sizeof(cf32_t *));
+    dump_sparse_matrix_cf32(mat, NULL, bs, 0, 0.0);
+    double r0 = realtime();
     exact_trace_sparse_reduced_echelon_form_ff_32(trace, mat, bs, st);
+    double r1 = realtime();
+    dump_sparse_matrix_cf32(mat, NULL, NULL, 1, r1 - r0);
 
     /* timings */
     ct1 = cputime();
@@ -4121,9 +4138,13 @@ static void exact_sparse_dense_linear_algebra_ff_32(
     /* generate updated dense D part via reduction of CD with AB */
     cf32_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_32(mat, bs, st);
+    dump_dense_matrix_cf32(dm, mat->np, ncr, 0, 0.0);
+    double r0 = realtime();
     if (mat->np > 0) {
         dm  = exact_dense_linear_algebra_ff_32(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_32(dm, ncr, st->fc);
+        double r1 = realtime();
+        dump_dense_matrix_cf32(dm, mat->np, ncr, 1, r1 - r0);
     }
 
     /* convert dense matrix back to sparse matrix representation,
@@ -4171,9 +4192,13 @@ static void probabilistic_sparse_dense_linear_algebra_ff_32_2(
     /* generate updated dense D part via reduction of CD with AB */
     cf32_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_32(mat, bs, st);
+    dump_dense_matrix_cf32(dm, mat->np, ncr, 0, 0.0);
+    double r0 = realtime();
     if (mat->np > 0) {
         dm  = probabilistic_dense_linear_algebra_ff_32(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_32(dm, mat->ncr, st->fc);
+        double r1 = realtime();
+        dump_dense_matrix_cf32(dm, mat->np, ncr, 1, r1 - r0);
     }
 
     /* convert dense matrix back to sparse matrix representation,
@@ -4222,7 +4247,11 @@ static void probabilistic_sparse_dense_linear_algebra_ff_32(
     cf32_t **dm = NULL;
     mat->np = 0;
     dm      = probabilistic_sparse_dense_echelon_form_ff_32(mat, bs, st);
+    dump_dense_matrix_cf32(dm, mat->np, ncr, 0, 0.0);
+    double r0 = realtime();
     dm      = interreduce_dense_matrix_ff_32(dm, mat->ncr, st->fc);
+    double r1 = realtime();
+    dump_dense_matrix_cf32(dm, mat->np, ncr, 1, r1 - r0);
 
     /* convert dense matrix back to sparse matrix representation,
      * use tmpcf for storing the coefficient arrays */

--- a/src/neogb/tools.c
+++ b/src/neogb/tools.c
@@ -19,6 +19,7 @@
 
 
 #include "tools.h"
+#include <sys/stat.h>
 
 /* cpu time */
 double cputime(void)
@@ -32,10 +33,199 @@ double cputime(void)
 /* wall time */
 double realtime(void)
 {
-	struct timeval t;
-	gettimeofday(&t, NULL);
-	t.tv_sec -= (2017 - 1970)*3600*24*365;
-	return (1. + (double)t.tv_usec + ((double)t.tv_sec*1000000.)) / 1000000.;
+        struct timeval t;
+        gettimeofday(&t, NULL);
+        t.tv_sec -= (2017 - 1970)*3600*24*365;
+        return (1. + (double)t.tv_usec + ((double)t.tv_sec*1000000.)) / 1000000.;
+}
+
+int save_matrices = 0;
+
+static void format_duration(double dur, char *buf, size_t n)
+{
+    int h = (int)(dur / 3600.0);
+    dur -= h * 3600.0;
+    int m = (int)(dur / 60.0);
+    dur -= m * 60.0;
+    int s = (int)dur;
+    int ms = (int)((dur - s) * 1000.0 + 0.5);
+    snprintf(buf, n, "%02d_%02d_%02d.%03d", h, m, s, ms);
+}
+
+void dump_dense_matrix_cf32(cf32_t **mat, len_t nrows, len_t ncols,
+                            int reduced, double duration)
+{
+    if (!save_matrices || !mat)
+        return;
+
+    mkdir("matrix_archive", 0755);
+
+    unsigned int id = (unsigned int)(rand() & 0xFFFFFF);
+    char ts[32] = "";
+    char fname[256];
+    if (reduced) {
+        format_duration(duration, ts, sizeof(ts));
+        snprintf(fname, sizeof(fname),
+                 "matrix_archive/rref_%lu_%lu_%s_%06x.smat",
+                 (unsigned long)nrows, (unsigned long)ncols, ts, id);
+    } else {
+        snprintf(fname, sizeof(fname),
+                 "matrix_archive/unrref_%lu_%lu_%06x.smat",
+                 (unsigned long)nrows, (unsigned long)ncols, id);
+    }
+
+    FILE *f = fopen(fname, "w");
+    if (!f)
+        return;
+
+    size_t nnz = 0;
+    if (!reduced) {
+        for (len_t i = 0; i < nrows; ++i) {
+            if (!mat[i])
+                continue;
+            for (len_t j = 0; j < ncols; ++j) {
+                if (mat[i][j] != 0)
+                    nnz++;
+            }
+        }
+    } else {
+        for (len_t idx = 0; idx < ncols; ++idx) {
+            len_t m = ncols - 1 - idx;
+            if (!mat[m])
+                continue;
+            len_t len = ncols - m;
+            for (len_t j = 0; j < len; ++j) {
+                if (mat[m][j] != 0)
+                    nnz++;
+            }
+        }
+    }
+
+    fprintf(f, "%lu %lu %lu\n", (unsigned long)nrows, (unsigned long)ncols,
+            (unsigned long)nnz);
+
+    if (!reduced) {
+        for (len_t i = 0; i < nrows; ++i) {
+            if (!mat[i])
+                continue;
+            for (len_t j = 0; j < ncols; ++j) {
+                if (mat[i][j] != 0) {
+                    fprintf(f, "%lu %lu %u\n", (unsigned long)i,
+                            (unsigned long)j, (unsigned)mat[i][j]);
+                }
+            }
+        }
+    } else {
+        len_t ridx = 0;
+        for (len_t idx = 0; idx < ncols; ++idx) {
+            len_t m = ncols - 1 - idx;
+            if (!mat[m])
+                continue;
+            len_t len = ncols - m;
+            for (len_t j = 0; j < len; ++j) {
+                if (mat[m][j] != 0) {
+                    fprintf(f, "%lu %lu %u\n", (unsigned long)ridx,
+                            (unsigned long)(m + j), (unsigned)mat[m][j]);
+                }
+            }
+            ridx++;
+        }
+    }
+
+    fclose(f);
+}
+
+void dump_sparse_matrix_cf32(mat_t *mat, const bs_t *tbr, const bs_t *bs,
+                             int reduced, double duration)
+{
+    if (!save_matrices)
+        return;
+
+    mkdir("matrix_archive", 0755);
+
+    unsigned int id = (unsigned int)(rand() & 0xFFFFFF);
+    len_t ncols = mat->nc;
+    len_t nrows = reduced ? mat->np : mat->nru + mat->nrl;
+
+    char ts[32] = "";
+    char fname[256];
+    if (reduced) {
+        format_duration(duration, ts, sizeof(ts));
+        snprintf(fname, sizeof(fname),
+                 "matrix_archive/rref_%lu_%lu_%s_%06x.smat",
+                 (unsigned long)nrows, (unsigned long)ncols, ts, id);
+    } else {
+        snprintf(fname, sizeof(fname),
+                 "matrix_archive/unrref_%lu_%lu_%06x.smat",
+                 (unsigned long)nrows, (unsigned long)ncols, id);
+    }
+
+    FILE *f = fopen(fname, "w");
+    if (!f)
+        return;
+
+    size_t nnz = 0;
+    if (!reduced) {
+        for (len_t i = 0; i < mat->nru; ++i) {
+            if (mat->rr[i])
+                nnz += mat->rr[i][LENGTH];
+        }
+        for (len_t i = 0; i < mat->nrl; ++i) {
+            if (mat->tr[i])
+                nnz += mat->tr[i][LENGTH];
+        }
+    } else {
+        for (len_t i = 0; i < mat->np; ++i) {
+            if (mat->tr[i])
+                nnz += mat->tr[i][LENGTH];
+        }
+    }
+
+    fprintf(f, "%lu %lu %lu\n", (unsigned long)nrows, (unsigned long)ncols,
+            (unsigned long)nnz);
+
+    if (!reduced) {
+        len_t idx = 0;
+        for (len_t i = 0; i < mat->nru; ++i, ++idx) {
+            hm_t *row = mat->rr[i];
+            if (!row)
+                continue;
+            cf32_t *cfs = bs->cf_32[row[COEFFS]];
+            len_t len = row[LENGTH];
+            hm_t *cols = row + OFFSET;
+            for (len_t j = 0; j < len; ++j) {
+                fprintf(f, "%lu %lu %u\n", (unsigned long)idx,
+                        (unsigned long)cols[j], (unsigned)cfs[j]);
+            }
+        }
+        for (len_t i = 0; i < mat->nrl; ++i, ++idx) {
+            hm_t *row = mat->tr[i];
+            if (!row)
+                continue;
+            cf32_t *cfs = tbr->cf_32[row[COEFFS]];
+            len_t len = row[LENGTH];
+            hm_t *cols = row + OFFSET;
+            for (len_t j = 0; j < len; ++j) {
+                fprintf(f, "%lu %lu %u\n", (unsigned long)idx,
+                        (unsigned long)cols[j], (unsigned)cfs[j]);
+            }
+        }
+    } else {
+        for (len_t i = 0; i < mat->np; ++i) {
+            hm_t *row = mat->tr[i];
+            if (!row)
+                continue;
+            cf32_t *cfs = mat->cf_32[row[COEFFS]];
+            len_t len = row[LENGTH];
+            hm_t *cols = row + OFFSET;
+            for (len_t j = 0; j < len; ++j) {
+                fprintf(f, "%lu %lu %u\n", (unsigned long)i,
+                        (unsigned long)cols[j], (unsigned)cfs[j]);
+            }
+        }
+    }
+
+    fclose(f);
 }
 
 static void construct_trace(

--- a/src/neogb/tools.h
+++ b/src/neogb/tools.h
@@ -35,6 +35,22 @@ double realtime(
     void
     );
 
+extern int save_matrices;
+void dump_dense_matrix_cf32(
+    cf32_t **mat,
+    len_t nrows,
+    len_t ncols,
+    int reduced,
+    double duration
+    );
+void dump_sparse_matrix_cf32(
+    mat_t *mat,
+    const bs_t *tbr,
+    const bs_t *bs,
+    int reduced,
+    double duration
+    );
+
 static inline uint8_t mod_p_inverse_8(
         const int16_t val,
         const int16_t p


### PR DESCRIPTION
## Summary
- add `-x` option to archive F4 matrices before and after row reduction
- implement dense matrix dump routine in tools
- hook archiving into 32-bit linear algebra routines
- expose option via command line help
- fix timing to exclude dump duration from reduction times

## Testing
- `./autogen.sh`
- `./configure`
- `make -j4`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_6840459685dc832ab262274584407a8d